### PR TITLE
Fix ability to use custom signed headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $options = array(
 	'dk_canonicalization' => 'nofws',
 	// if you want to sign the mail on a different list of headers than the
 	// default one (see class constructor). Case-insensitive.
-	'signature_headers' => array(
+	'signed_headers' => array(
 		'message-Id',
 		'Content-type',
 		'To',

--- a/mail-signature.class.php
+++ b/mail-signature.class.php
@@ -158,7 +158,7 @@ class mail_signature {
 		
 			// lower case fields
 			foreach($options['signed_headers'] as $key => $value){
-				$options['signed_headers']['key'] = strtolower($value);
+				$options['signed_headers'][$key] = strtolower($value);
 			}
 			
 			// delete the default fields if a custom list is provided, not merge

--- a/test.php
+++ b/test.php
@@ -72,7 +72,7 @@ $options = array(
 	'dk_canonicalization' => 'nofws',
 	// if you want to sign the mail on a different list of headers than the
 	// default one (see class constructor). Case-insensitive.
-	'signature_headers' => array(
+	'signed_headers' => array(
 		'message-Id',
 		'Content-type',
 		'To',


### PR DESCRIPTION
The code expects an option named "signed_headers", but the documentation and
test.php was showing "signature_headers". This meant the example code and
test.php would not work as expected.